### PR TITLE
feat: Add plugin version retrieval endpoint and update GUI submodule

### DIFF
--- a/src/main/kotlin/ai/devchat/plugin/IDEServer.kt
+++ b/src/main/kotlin/ai/devchat/plugin/IDEServer.kt
@@ -49,6 +49,7 @@ import java.awt.Point
 import java.io.File
 import java.net.ServerSocket
 import kotlin.reflect.full.memberFunctions
+import com.intellij.ide.plugins.PluginManagerCore
 
 
 @Serializable
@@ -98,6 +99,17 @@ class IDEServer(private var project: Project): Disposable {
                 json()
             }
             routing {
+                post("/get_extension_version") {
+                    val currentPlugin = try {
+                        PluginManagerCore.getLoadedPlugins().find { plugin ->
+                            plugin.pluginClassLoader == IDEServer::class.java.classLoader
+                        }
+                    } catch (e: Exception) {
+                        null
+                    }
+                    call.respond(Result(currentPlugin?.version ?: "unknown"))
+                }
+
                 post("/find_def_locations") {
                     val body: ReqLocation = call.receive()
                     val definitions = try {


### PR DESCRIPTION
### Changes

- Add new POST endpoint `/get_extension_version` to fetch plugin version
- Implement PluginManagerCore to locate current plugin by classloader
- Return version or "unknown" in standardized Result format
- Update GUI submodule