### PR TITLE
fix: Improve IDE compatibility and fix PsiElement offset access

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "ai.devchat"
-version = "0.3.3"
+version = "0.3.9"
 
 repositories {
     mavenCentral()
@@ -38,7 +38,7 @@ configurations.all {
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
-    version.set("2023.2.5")
+    version.set("2022.3.3")
     type.set("IC") // Target IDE Platform
 
     plugins.set(listOf(/* Plugin Dependencies */))
@@ -100,7 +100,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("223")
-        untilBuild.set("242.*")
+        untilBuild.set("243.*")
     }
 
     signPlugin {

--- a/src/main/kotlin/ai/devchat/common/IDEUtils.kt
+++ b/src/main/kotlin/ai/devchat/common/IDEUtils.kt
@@ -328,7 +328,7 @@ object IDEUtils {
         var currentIndex = 0
 
         for (descriptor in sortedDescriptors) {
-            val range = descriptor.range.shiftRight(-startOffset)
+            val range = descriptor.range.shiftRight(-this.textRange.startOffset)
             if (range.startOffset >= currentIndex) {
                 builder.append(text, currentIndex, range.startOffset)
                 builder.append(descriptor.placeholderText)

--- a/src/main/kotlin/ai/devchat/core/handlers/OpenLinkRequestHandler.kt
+++ b/src/main/kotlin/ai/devchat/core/handlers/OpenLinkRequestHandler.kt
@@ -17,7 +17,7 @@ class OpenLinkRequestHandler(project: Project, requestAction: String, metadata: 
 
     override fun action() {
         val url = payload!!.getString("url")
-        BrowserUtil.browse(URL(url))
+        BrowserUtil.browse(url)
         send()
     }
 }

--- a/src/main/kotlin/ai/devchat/plugin/DevChatToolWindowFactory.kt
+++ b/src/main/kotlin/ai/devchat/plugin/DevChatToolWindowFactory.kt
@@ -59,7 +59,7 @@ class DevChatToolWindowFactory : ToolWindowFactory, DumbAware, Disposable {
         Log.info("-----------> DevChatToolWindowFactory.createToolWindowContent started")
 
         try {
-            project.service<RecentFilesTracker>()
+            project.getService(RecentFilesTracker::class.java)
             Log.info("-----------> RecentFilesTracker service initialized")
 
             val devChatService = project.getService(DevChatService::class.java)

--- a/src/main/kotlin/ai/devchat/plugin/IDEServer.kt
+++ b/src/main/kotlin/ai/devchat/plugin/IDEServer.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerEx
 import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.codeInsight.navigation.actions.GotoTypeDeclarationAction
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.lang.Language
 import com.intellij.lang.annotation.HighlightSeverity.INFORMATION
 import com.intellij.openapi.Disposable
@@ -30,6 +31,8 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.*
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
 import io.ktor.http.*
@@ -49,7 +52,6 @@ import java.awt.Point
 import java.io.File
 import java.net.ServerSocket
 import kotlin.reflect.full.memberFunctions
-import com.intellij.ide.plugins.PluginManagerCore
 
 
 @Serializable
@@ -101,7 +103,7 @@ class IDEServer(private var project: Project): Disposable {
             routing {
                 post("/get_extension_version") {
                     val currentPlugin = try {
-                        PluginManagerCore.getLoadedPlugins().find { plugin ->
+                        PluginManager.getPlugins().find { plugin ->
                             plugin.pluginClassLoader == IDEServer::class.java.classLoader
                         }
                     } catch (e: Exception) {
@@ -548,7 +550,7 @@ fun PsiElement.getRange(): Range? {
     }
 
     return try {
-        Range(calculatePosition(this.startOffset), calculatePosition(this.endOffset))
+        Range(calculatePosition(this.textRange.startOffset), calculatePosition(this.textRange.endOffset))
     } catch (e: Exception) {
         Log.warn(e.toString())
         null

--- a/src/main/kotlin/ai/devchat/plugin/ToolWindowStateListener.kt
+++ b/src/main/kotlin/ai/devchat/plugin/ToolWindowStateListener.kt
@@ -4,7 +4,6 @@ import ai.devchat.common.Constants.ASSISTANT_NAME_ZH
 import ai.devchat.common.DevChatBundle
 import ai.devchat.storage.DevChatState
 import ai.devchat.storage.ToolWindowState
-import ai.grazie.utils.applyIf
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
@@ -15,13 +14,12 @@ class ToolWindowStateListener : ToolWindowManagerListener {
         super.toolWindowsRegistered(ids, toolWindowManager)
         ids.find { it == ASSISTANT_NAME_ZH }?.let {
             runInEdt {
-                toolWindowManager.getToolWindow(it)?.applyIf(
-                    DevChatState.instance.lastToolWindowState == ToolWindowState.SHOWN.name
-                ) {
-                    while (!this.isAvailable) {
+                val toolWindow = toolWindowManager.getToolWindow(it)
+                if (DevChatState.instance.lastToolWindowState == ToolWindowState.SHOWN.name && toolWindow != null) {
+                    while (!toolWindow.isAvailable) {
                         Thread.sleep(1000)
                     }
-                    this.show()
+                    toolWindow.show()
                 }
             }
         }

--- a/src/main/kotlin/ai/devchat/plugin/completion/actions/TriggerCompletion.kt
+++ b/src/main/kotlin/ai/devchat/plugin/completion/actions/TriggerCompletion.kt
@@ -13,7 +13,7 @@ import com.intellij.openapi.components.service
 class TriggerCompletion : AnAction() {
   override fun actionPerformed(e: AnActionEvent) {
     val completionScheduler = service<CompletionProvider>()
-    val editor = e.getRequiredData(CommonDataKeys.EDITOR)
+    val editor = e.getData(CommonDataKeys.EDITOR) ?: return
     val offset = editor.caretModel.primaryCaret.offset
     completionScheduler.provideCompletion(editor, offset, manually = true)
   }

--- a/src/main/kotlin/ai/devchat/plugin/hints/DocStringCVProvider.kt
+++ b/src/main/kotlin/ai/devchat/plugin/hints/DocStringCVProvider.kt
@@ -13,14 +13,14 @@ import javax.swing.Icon
 class DocStringCVProvider : ChatCVProviderBase() {
     override fun buildPayload(editor: Editor, element: PsiElement): JSONObject {
         val document = editor.document
-        val startLine = document.getLineNumber(element.startOffset)
+        val startLine = document.getLineNumber(element.textRange.startOffset)
         val lineStartOffset = document.getLineStartOffset(startLine)
-        val startOffset = if (document.text.substring(lineStartOffset, element.startOffset).isBlank()) {
+        val startOffset = if (document.text.substring(lineStartOffset, element.textRange.startOffset).isBlank()) {
             lineStartOffset
         } else {
-            element.startOffset
+            element.textRange.startOffset
         }
-        editor.selectionModel.setSelection(startOffset, null, element.endOffset)
+        editor.selectionModel.setSelection(startOffset, null, element.textRange.endOffset)
         return JSONObject(mapOf("message" to "/docstring"))
     }
 

--- a/src/main/kotlin/ai/devchat/plugin/hints/ExplainCodeCVProvider.kt
+++ b/src/main/kotlin/ai/devchat/plugin/hints/ExplainCodeCVProvider.kt
@@ -11,7 +11,7 @@ import javax.swing.Icon
 
 class ExplainCodeCVProvider : ChatCVProviderBase() {
     override fun buildPayload(editor: Editor, element: PsiElement): JSONObject {
-        editor.selectionModel.setSelection(element.startOffset, null, element.endOffset)
+        editor.selectionModel.setSelection(element.textRange.startOffset, null, element.textRange.endOffset)
         return JSONObject(mapOf("message" to "/explain"))
     }
 

--- a/src/main/kotlin/ai/devchat/plugin/hints/UnitTestsCVProvider.kt
+++ b/src/main/kotlin/ai/devchat/plugin/hints/UnitTestsCVProvider.kt
@@ -17,10 +17,10 @@ class UnitTestsCVProvider : ChatCVProviderBase() {
                 "message" to "/unit_tests " + listOf(
                     FileDocumentManager.getInstance().getFile(editor.document)!!.path,
                     (element as? PsiNamedElement)?.name,
-                    editor.document.getLineNumber(element.startOffset),
-                    editor.document.getLineNumber(element.endOffset),
-                    editor.document.getLineNumber(element.parent.startOffset),
-                    editor.document.getLineNumber(element.parent.endOffset),
+                    editor.document.getLineNumber(element.textRange.startOffset),
+                    editor.document.getLineNumber(element.textRange.endOffset),
+                    editor.document.getLineNumber(element.parent.textRange.startOffset),
+                    editor.document.getLineNumber(element.parent.textRange.endOffset),
                 ).joinToString(":::"),
             )
         )


### PR DESCRIPTION
## Changes

- Fix: Use `textRange` property for PsiElement offset access throughout the codebase
- Fix: Update line number retrieval in UnitTestsCVProvider
- Fix: Simplify URL handling with direct BrowserUtil.browse(url)
- Fix: Replace PluginManagerCore with PluginManager for version retrieval
- Refactor: Improve service initialization and ToolWindowStateListener
- Chore: Bump version from 0.3.3 to 0.3.9
- Chore: Update IDE compatibility (target 2022.3.3 and extend to build 243.*)

This PR addresses several issues with PsiElement offset access and improves overall IDE compatibility.